### PR TITLE
Allow timeouts to be configured.

### DIFF
--- a/sf-jdbc-driver/src/main/java/com/ascendix/jdbc/salesforce/ForceDriver.java
+++ b/sf-jdbc-driver/src/main/java/com/ascendix/jdbc/salesforce/ForceDriver.java
@@ -80,6 +80,8 @@ public class ForceDriver implements Driver {
             if (resolveBooleanProperty(properties, "insecurehttps", false)) {
                 HttpsTrustManager.allowAllSSL();
             }
+            info.setReadTimeout(resolveIntProperty(properties, "readTimeout", info.getReadTimeout()));
+            info.setConnectionTimeout(resolveIntProperty(properties, "connectionTimeout", info.getConnectionTimeout()));
             info.setApiVersion(resolveStringProperty(properties, "api", ForceService.DEFAULT_API_VERSION));
             info.setLoginDomain(resolveStringProperty(properties, "loginDomain", ForceService.DEFAULT_LOGIN_DOMAIN));
 
@@ -111,6 +113,8 @@ public class ForceDriver implements Driver {
                 if (resolveBooleanProperty(newProperties, "insecurehttps", false)) {
                     HttpsTrustManager.allowAllSSL();
                 }
+                newInfo.setReadTimeout(resolveIntProperty(newProperties, "readTimeout", newInfo.getReadTimeout()));
+                newInfo.setConnectionTimeout(resolveIntProperty(newProperties, "connectionTimeout", newInfo.getConnectionTimeout()));
                 newInfo.setApiVersion(resolveStringProperty(newProperties, "api", ForceService.DEFAULT_API_VERSION));
                 newInfo.setLoginDomain(resolveStringProperty(newProperties, "loginDomain", ForceService.DEFAULT_LOGIN_DOMAIN));
 
@@ -160,6 +164,18 @@ public class ForceDriver implements Driver {
         return defaultValue;
     }
 
+
+    private static int resolveIntProperty(Properties properties, String propertyName, int defaultValue) {
+        String intVal = properties.getProperty(propertyName);
+        if (intVal != null) {
+            try {
+                return Integer.parseInt(intVal);
+            } catch (NumberFormatException ignored) {
+                logger.log(Level.WARNING, "[ForceDriver] ignored invalid int property=" + propertyName + " value=" + intVal);
+            }
+        }
+        return defaultValue;
+    }
 
     public static Properties getConnStringProperties(String urlString) throws IOException {
         Properties result = new Properties();

--- a/sf-jdbc-driver/src/main/java/com/ascendix/jdbc/salesforce/connection/ForceConnectionInfo.java
+++ b/sf-jdbc-driver/src/main/java/com/ascendix/jdbc/salesforce/connection/ForceConnectionInfo.java
@@ -15,4 +15,6 @@ public class ForceConnectionInfo {
     private String apiVersion = ForceService.DEFAULT_API_VERSION;
     private String loginDomain;
     private String clientName;
+    private int connectionTimeout = 10 * 1000;
+    private int readTimeout = 30 * 1000;
 }

--- a/sf-jdbc-driver/src/main/java/com/ascendix/jdbc/salesforce/connection/ForceService.java
+++ b/sf-jdbc-driver/src/main/java/com/ascendix/jdbc/salesforce/connection/ForceService.java
@@ -22,8 +22,8 @@ public class ForceService {
 
     public static final String DEFAULT_LOGIN_DOMAIN = "login.salesforce.com";
     private static final String SANDBOX_LOGIN_DOMAIN = "test.salesforce.com";
-    private static final long CONNECTION_TIMEOUT = TimeUnit.SECONDS.toMillis(10);
-    private static final long READ_TIMEOUT = TimeUnit.SECONDS.toMillis(30);
+    private static final long OAUTH_CONNECTION_TIMEOUT = TimeUnit.SECONDS.toMillis(10);
+    private static final long OAUTH_READ_TIMEOUT = TimeUnit.SECONDS.toMillis(30);
     public static final String DEFAULT_API_VERSION = "50.0";
     public static final int EXPIRE_AFTER_CREATE = 60;
     public static final int EXPIRE_STORE_SIZE = 16;
@@ -43,7 +43,7 @@ public class ForceService {
     }
 
     private static String getPartnerUrlFromUserInfo(String accessToken, boolean sandbox) {
-        return new ForceOAuthClient(CONNECTION_TIMEOUT, READ_TIMEOUT).getUserInfo(accessToken, sandbox).getPartnerUrl();
+        return new ForceOAuthClient(OAUTH_CONNECTION_TIMEOUT, OAUTH_READ_TIMEOUT).getUserInfo(accessToken, sandbox).getPartnerUrl();
     }
 
     public static PartnerConnection createPartnerConnection(ForceConnectionInfo info) throws ConnectionException {
@@ -52,6 +52,8 @@ public class ForceService {
 
     private static PartnerConnection createConnectionBySessionId(ForceConnectionInfo info) throws ConnectionException {
         ConnectorConfig partnerConfig = new ConnectorConfig();
+        partnerConfig.setReadTimeout(info.getReadTimeout());
+        partnerConfig.setConnectionTimeout(info.getConnectionTimeout());
         partnerConfig.setSessionId(info.getSessionId());
 
         if (info.getSandbox() != null) {
@@ -76,6 +78,8 @@ public class ForceService {
             throws ConnectionException {
 
         ConnectorConfig partnerConfig = new ConnectorConfig();
+        partnerConfig.setReadTimeout(info.getReadTimeout());
+        partnerConfig.setConnectionTimeout(info.getConnectionTimeout());
         partnerConfig.setUsername(info.getUserName());
         partnerConfig.setPassword(info.getPassword());
 


### PR DESCRIPTION
Allow `readTimeout` & `connectionTimeout` to be specified as jdbc properties, and use default values if none are provided. Currently if there is any issue with the salesforce endpoint (we have had some problems with it), there is no way to limit the damage with a connection/read timeout.